### PR TITLE
[追加]ストック食材期限の警告通知機能

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,3 +57,4 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'devise'
 gem "cocoon"
 gem 'pry-rails'
+gem "enum_help"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,8 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    enum_help (0.0.17)
+      activesupport (>= 3.0.0)
     erubi (1.10.0)
     ffi (1.15.4)
     globalid (1.0.0)
@@ -236,6 +238,7 @@ DEPENDENCIES
   capybara (>= 3.26)
   cocoon
   devise
+  enum_help
   image_processing (~> 1.2)
   jbuilder (~> 2.7)
   listen (~> 3.3)

--- a/app/controllers/public/stock_foods_controller.rb
+++ b/app/controllers/public/stock_foods_controller.rb
@@ -9,6 +9,10 @@ class Public::StockFoodsController < ApplicationController
     else
       redirect_to user_path(@user)
     end
+    @notifications = current_user.notifications
+    @notifications.where(is_checked: false).each do |notification|
+      notification.update(is_checked: true)
+    end
   end
 
   def create

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,0 +1,8 @@
+class Notification < ApplicationRecord
+  default_scope->{order(created_at: :desc)}
+
+  belongs_to :user
+  belongs_to :stock_food
+
+  enum action: { warning: 1, expired: 2}
+end

--- a/app/models/stock_food.rb
+++ b/app/models/stock_food.rb
@@ -1,4 +1,5 @@
 class StockFood < ApplicationRecord
   belongs_to :user
   validates :name, presence: true
+  has_one :notification, dependent: :destroy
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,7 @@ class User < ApplicationRecord
   has_many :stock_foods, dependent: :destroy
   has_many :favorites, dependent: :destroy
   has_many :recipe_comments, dependent: :destroy
+  has_many :notifications, dependent: :destroy
 
   has_one_attached :profile_image
 

--- a/app/views/public/stock_foods/index.html.erb
+++ b/app/views/public/stock_foods/index.html.erb
@@ -22,6 +22,7 @@
           <tr>
             <td><strong>ストック食品</strong></td>
             <td><strong>消費期限</strong></td>
+            <td></td>
           </tr>
       </thead>
       <tbody>
@@ -29,6 +30,13 @@
         <tr>
           <td><%= stock_food.name %></td>
           <td><%= stock_food.expiration_date %></td>
+          <td>
+            <% if stock_food.notification.action == "expired" %>
+              期限切れ
+            <% elsif stock_food.notification.action == "warning" %>
+              もうすぐ切れます
+            <% end %>
+          </td>
         </tr>
         <% end %>
       </tbody>

--- a/db/migrate/20220403133640_create_notifications.rb
+++ b/db/migrate/20220403133640_create_notifications.rb
@@ -1,0 +1,12 @@
+class CreateNotifications < ActiveRecord::Migration[6.1]
+  def change
+    create_table :notifications do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :stock_food, null: false, foreign_key: true
+      t.integer :action
+      t.boolean :is_checked, default: false, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_31_130648) do
+ActiveRecord::Schema.define(version: 2022_04_03_133640) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -71,6 +71,17 @@ ActiveRecord::Schema.define(version: 2022_03_31_130648) do
     t.string "quantity", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "notifications", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.integer "stock_food_id", null: false
+    t.integer "action"
+    t.boolean "is_checked", default: false, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["stock_food_id"], name: "index_notifications_on_stock_food_id"
+    t.index ["user_id"], name: "index_notifications_on_user_id"
   end
 
   create_table "recipe_comments", force: :cascade do |t|
@@ -156,6 +167,8 @@ ActiveRecord::Schema.define(version: 2022_03_31_130648) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "notifications", "stock_foods"
+  add_foreign_key "notifications", "users"
   add_foreign_key "recipe_tags", "recipes"
   add_foreign_key "recipe_tags", "tags"
 end

--- a/lib/tasks/notification.rake
+++ b/lib/tasks/notification.rake
@@ -1,0 +1,21 @@
+namespace :task do
+  desc "notification/1日1回動かす"
+  task :notification => :environment do
+    today = Date.today
+    stock_foods = StockFood.all
+    n = stock_foods.count
+    today = Date.today
+    stock_foods.each do |stock_food|
+      user = stock_food.user
+      if today + 3 == stock_food.expiration_date
+        Notification.create(stock_food_id: stock_food.id, user_id: user.id, action: "warning")
+      elsif stock_food.notification == nil && today > stock_food.expiration_date
+        Notification.create(stock_food_id: stock_food.id, user_id: user.id, action: "expired")
+      elsif stock_food.notification.present? && today > stock_food.expiration_date.to_date
+        stock_food.notification.update(action: "expired")
+      end
+      n -= 1
+      puts "残り#{n}/#{stock_foods.count}"
+    end
+  end
+end

--- a/test/fixtures/notifications.yml
+++ b/test/fixtures/notifications.yml
@@ -1,0 +1,13 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  stock_food: one
+  action: 1
+  is_checked: false
+
+two:
+  user: two
+  stock_food: two
+  action: 1
+  is_checked: false

--- a/test/models/notification_test.rb
+++ b/test/models/notification_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class NotificationTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
**ストック食材期限の警告通知機能の実装**
ストック食材の消費期限が３日前になると"warning"となり、過ぎると"expired"になる。
Rakeタスクの作成を作成し、ターミナルで_"rails task:notification"_を実施することで
ストック食材の期限によってnotificationsテーブルのactionカラムを"warning"か"expired"を保存。
notificationsテーブルは通知テーブルのこと。
userは複数のnotificationsと、一つのストック食材は一つのnotificationとリレーションがつながっている。
notificationsテーブルにはuser_id, stock_food_id, action, is_checkedカラムがある。
今後、レイアウトや通知機能を実装する。