### PR TITLE
[修正]ストック食材期限警告機能

### DIFF
--- a/app/views/public/stock_foods/index.html.erb
+++ b/app/views/public/stock_foods/index.html.erb
@@ -22,7 +22,7 @@
           <tr>
             <td><strong>ストック食品</strong></td>
             <td><strong>消費期限</strong></td>
-            <td></td>
+            <td><strong>今日の日付：<%= Date.today %></strong></td>
           </tr>
       </thead>
       <tbody>
@@ -31,10 +31,11 @@
           <td><%= stock_food.name %></td>
           <td><%= stock_food.expiration_date %></td>
           <td>
-            <% if stock_food.notification.action == "expired" %>
-              期限切れ
+            <% if stock_food.notification.nil? %>
             <% elsif stock_food.notification.action == "warning" %>
               もうすぐ切れます
+            <% elsif stock_food.notification.action == "expired" %>
+              期限切れ
             <% end %>
           </td>
         </tr>

--- a/lib/tasks/notification.rake
+++ b/lib/tasks/notification.rake
@@ -4,12 +4,11 @@ namespace :task do
     today = Date.today
     stock_foods = StockFood.all
     n = stock_foods.count
-    today = Date.today
     stock_foods.each do |stock_food|
       user = stock_food.user
-      if today + 3 == stock_food.expiration_date
+      if today + 3 == stock_food.expiration_date.to_date || today + 2 == stock_food.expiration_date.to_date || today + 1 == stock_food.expiration_date.to_date
         Notification.create(stock_food_id: stock_food.id, user_id: user.id, action: "warning")
-      elsif stock_food.notification == nil && today > stock_food.expiration_date
+      elsif stock_food.notification.nil? && today > stock_food.expiration_date.to_date
         Notification.create(stock_food_id: stock_food.id, user_id: user.id, action: "expired")
       elsif stock_food.notification.present? && today > stock_food.expiration_date.to_date
         stock_food.notification.update(action: "expired")


### PR DESCRIPTION
**Rake taskの修正**

- rake task(task:notification)実行時に、今まではストック食材期限日が三日前になるとactionを"warning"にする処理が行われるが、ストック食材登録時の日時が消費期限の2~1日前にされるとrake task(task:notification)実行時にactionを"warning"にする処理が行われなくなる。
 - 2~1日前に登録されても処理が実施されるように修正済み